### PR TITLE
Update readme and delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 services: key-vault
 platforms: nodejs
-author: dadesber
+author: lusitanian
 ---
 
 # Authentication sample for Azure Key Vault using the Azure Node SDK

--- a/authentication_sample.js
+++ b/authentication_sample.js
@@ -114,7 +114,7 @@ function runSample(demoCallback) {
         // Add a delay to wait for KV DNS record to be created. See: https://github.com/Azure/azure-sdk-for-node/pull/1938
         setTimeout(() => {
             demoCallback(result.properties.vaultUri);
-        }, 5000);
+        }, 15000);
     })
     .catch( (err) => { 
         console.log(err); 


### PR DESCRIPTION
Update the delay after creating a demo Key Vault to 15s.
Correct README

Note that I didn't change the declaration of the AuthenticationContext as, in the node SDK, it uses a global cache by default. 